### PR TITLE
ENH: add option to skip "fluffy" ice scaling factor for rad approach

### DIFF
--- a/emc2/core/model.py
+++ b/emc2/core/model.py
@@ -37,10 +37,11 @@ class Model():
     Rho_hyd: dict
        A dictionary whose keys are the names of the model's hydrometeor classes and
        whose values are the density of said hydrometeors in :math:`kg\ m^{-3}`
-    fluffy: dict
+    fluffy: dict or None
        A dictionary whose keys are the names of the model's ice hydrometeor classes and
        whose values are the ice fluffiness factor for the fwd calculations using r_e,
        where values of 0 - equal volume sphere, 1 - fluffy sphere i.e., diameter = maximum dimension.
+       If None, then not applying this correction factor
     lidar_ratio: dict
        A dictionary whose keys are the names of the model's hydrometeor classes and
        whose values are the lidar_ratio of said hydrometeors.

--- a/emc2/simulator/lidar_moments.py
+++ b/emc2/simulator/lidar_moments.py
@@ -367,7 +367,7 @@ def calc_lidar_bulk(instrument, model, is_conv, p_values, z_values, OD_from_sfc=
     dz = np.tile(np.diff(z_values, axis=1, append=0.), (model.num_subcolumns, 1, 1))
     for hyd_type in hyd_types:
         rad_A = True  # calculate total surface area using classic derivation from r_eff and q_i
-        if hyd_type[-1] == 'l':
+        if hyd_type[-1] == 'l':  # liquid hydrometeors
             rho_b = model.Rho_hyd[hyd_type]  # bulk water
             re_array = np.tile(model.ds[re_fields[hyd_type]], (model.num_subcolumns, 1, 1))
             if model.lambda_field is not None:  # assuming my and lambda can be provided only for liq hydrometeors
@@ -410,18 +410,24 @@ def calc_lidar_bulk(instrument, model, is_conv, p_values, z_values, OD_from_sfc=
                 rho_b = instrument.rho_i  # bulk ice
                 re_interped =  model.interpobj["bulk"]["ri_eff"]((
                     i_calc_kws["Fr_in"], i_calc_kws["rho_r_in"], i_calc_kws["q_norm_in"])) * 1e6  # um for now
-                rhoi_eff_interped =  model.interpobj["bulk"]["rho_m_weight"]((
-                    i_calc_kws["Fr_in"], i_calc_kws["rho_r_in"], i_calc_kws["q_norm_in"]))
-                re_array = np.tile(re_interped * rhoi_eff_interped / rho_b, (model.num_subcolumns, 1, 1))
+                if model.fluffy is None:  # fluffy is used here only to determine if the approach is to be implemented
+                    re_array = np.tile(re_interped, (model.num_subcolumns, 1, 1))
+                else:
+                    rhoi_eff_interped =  model.interpobj["bulk"]["rho_m_weight"]((
+                        i_calc_kws["Fr_in"], i_calc_kws["rho_r_in"], i_calc_kws["q_norm_in"]))
+                    re_array = np.tile(re_interped * rhoi_eff_interped / rho_b, (model.num_subcolumns, 1, 1))
         else:
             rho_b = instrument.rho_i  # bulk ice
             rho_hyd = model.Rho_hyd[hyd_type]
             if rho_hyd == 'variable':
                 rho_hyd = model.ds[model.variable_density[hyd_type]].values
-            fi_factor = model.fluffy[hyd_type].magnitude * rho_hyd / rho_b + \
-                (1 - model.fluffy[hyd_type].magnitude) * (rho_hyd / rho_b) ** (1 / 3)
-            re_array = np.tile(model.ds[re_fields[hyd_type]].values * fi_factor,
-                               (model.num_subcolumns, 1, 1))
+            if model.fluffy is None:
+                re_array = np.tile(model.ds[re_fields[hyd_type]].values, (n_subcolumns, 1, 1))
+            else:
+                fi_factor = model.fluffy[hyd_type].magnitude * rho_hyd / rho_b + \
+                    (1 - model.fluffy[hyd_type].magnitude) * (rho_hyd / rho_b) ** (1 / 3)
+                re_array = np.tile(model.ds[re_fields[hyd_type]].values * fi_factor,
+                                   (model.num_subcolumns, 1, 1))
 
         sub_frac_arr = model.ds["%s_frac_subcolumns_%s" % (cloud_str, hyd_type)].values
         if rad_A:


### PR DESCRIPTION
This implicit option enables to skip the ice scaling factor if one sets `model.fluffy=None`. This option is currently not an optional input parameter to the `Model` class `__init__` method since models generally apply this correction before sending microphysics output to the radiation schemes.